### PR TITLE
Optimize object lookup calls

### DIFF
--- a/d2data/d2datadict/object_lookup.go
+++ b/d2data/d2datadict/object_lookup.go
@@ -1,60 +1,7 @@
 package d2datadict
 
-import (
-	"log"
-)
 
-type ObjectType int
-
-const (
-	ObjectTypeCharacter ObjectType = 1
-	ObjectTypeItem      ObjectType = 2
-)
-
-type ObjectLookupRecord struct {
-	Act           int
-	Type          ObjectType
-	Id            int
-	Description   string
-	ObjectsTxtId  int
-	MonstatsTxtId int
-	Direction     int
-	Base          string
-	Token         string
-	Mode          string
-	Class         string
-	HD            string
-	TR            string
-	LG            string
-	RA            string
-	LA            string
-	RH            string
-	LH            string
-	SH            string
-	S1            string
-	S2            string
-	S3            string
-	S4            string
-	S5            string
-	S6            string
-	S7            string
-	S8            string
-	ColorMap      string
-	Index         int
-}
-
-func LookupObject(act, typ, id int) *ObjectLookupRecord {
-	for _, lookup := range ObjectLookups {
-		if lookup.Act != act || int(lookup.Type) != typ || lookup.Id != id {
-			continue
-		}
-		return &lookup
-	}
-	log.Panicf("Failed to look up object Act: %d, Type: %d, Id: %d", act, typ, id)
-	return nil
-}
-
-var ObjectLookups = []ObjectLookupRecord{
+var objectLookups = []ObjectLookupRecord{
 	{Act: 1, Type: ObjectTypeCharacter, Id: 0, Description: "gheed-ACT 1 TABLE", ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Base: "/Data/Global/Monsters", Token: "GH", Mode: "NU", Class: "HTH", TR: "LIT", Index: -1},
 	{Act: 1, Type: ObjectTypeCharacter, Id: 1, Description: "cain1-ACT 1 TABLE", ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Base: "/Data/Global/Monsters", Token: "DC", Mode: "NU", Class: "HTH", TR: "LIT", Index: -1},
 	{Act: 1, Type: ObjectTypeCharacter, Id: 2, Description: "akara-ACT 1 TABLE", ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Base: "/Data/Global/Monsters", Token: "PS", Mode: "NU", Class: "HTH", TR: "LIT", Index: -1},
@@ -7946,5 +7893,4 @@ var ObjectLookups = []ObjectLookupRecord{
 	{Act: 5, Type: ObjectTypeItem, Id: 720, Description: "Dummy-fire place guy", ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Base: "/Data/Global/Objects", Token: "7y", Mode: "NU", Class: "HTH", TR: "LIT", Index: -1},
 	{Act: 5, Type: ObjectTypeItem, Id: 721, Description: "Dummy-door blocker", ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Base: "/Data/Global/Objects", Token: "ss", Index: -1},
 	{Act: 5, Type: ObjectTypeItem, Id: 722, Description: "Dummy-door blocker", ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Base: "/Data/Global/Objects", Token: "ss", Index: -1},
-	{Act: -1, Type: -1, Id: -1, ObjectsTxtId: -1, MonstatsTxtId: -1, Direction: -1, Index: -1},
 }

--- a/d2data/d2datadict/object_query.go
+++ b/d2data/d2datadict/object_query.go
@@ -1,0 +1,90 @@
+package d2datadict
+
+import (
+	"log"
+)
+
+type ObjectType int
+
+const (
+	ObjectTypeCharacter ObjectType = 1
+	ObjectTypeItem      ObjectType = 2
+)
+
+type ObjectLookupRecord struct {
+	Act           int
+	Type          ObjectType
+	Id            int
+	Description   string
+	ObjectsTxtId  int
+	MonstatsTxtId int
+	Direction     int
+	Base          string
+	Token         string
+	Mode          string
+	Class         string
+	HD            string
+	TR            string
+	LG            string
+	RA            string
+	LA            string
+	RH            string
+	LH            string
+	SH            string
+	S1            string
+	S2            string
+	S3            string
+	S4            string
+	S5            string
+	S6            string
+	S7            string
+	S8            string
+	ColorMap      string
+	Index         int
+}
+
+func LookupObject(act, typ, id int) *ObjectLookupRecord {
+	object := lookupObject(act, typ, id, indexedObjects)
+	if object == nil {
+		log.Panicf("Failed to look up object Act: %d, Type: %d, Id: %d", act, typ, id)
+	}
+	return object
+}
+
+func lookupObject(act, typ, id int, objects [][][]*ObjectLookupRecord) *ObjectLookupRecord {
+	if objects[act] != nil && objects[act][typ] != nil && objects[act][typ][id] != nil {
+		return objects[act][typ][id]
+	}
+	return nil
+}
+
+func init() {
+	indexedObjects = indexObjects(objectLookups)
+}
+
+func indexObjects(objects []ObjectLookupRecord) [][][]*ObjectLookupRecord {
+	// Allocating 6 to allow Acts 1-5 without requiring a -1 at every read.
+	indexedObjects = make([][][]*ObjectLookupRecord, 6)
+	for i, _ := range objects {
+		record := &objects[i]
+		if indexedObjects[record.Act] == nil {
+			// Likewise allocating 3 so a -1 isn't necessary.
+			indexedObjects[record.Act] = make([][]*ObjectLookupRecord, 3)
+		}
+
+		if indexedObjects[record.Act][record.Type] == nil {
+			// For simplicity, allocating with length 1000 then filling the values in by index.
+			// If ids in the dictionary ever surpass 1000, raise this number.
+			indexedObjects[record.Act][record.Type] = make([]*ObjectLookupRecord, 1000)
+		}
+
+		indexedObjects[record.Act][record.Type][record.Id] = record
+	}
+
+	return indexedObjects
+}
+
+// Indexed slice of object records for quick lookups.
+// nil checks should be done for uninitialized values at each level.
+// [Act 1-5][Type 1-2][Id 0-855]
+var indexedObjects [][][]*ObjectLookupRecord

--- a/d2data/d2datadict/object_query_test.go
+++ b/d2data/d2datadict/object_query_test.go
@@ -1,0 +1,40 @@
+package d2datadict
+
+import (
+	testify "github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// Verify the lookup returns the right object after indexing.
+func TestIndexObjects(t *testing.T) {
+	assert := testify.New(t)
+
+	testObjects := []ObjectLookupRecord{
+		{Act: 1, Type: ObjectTypeCharacter, Id: 0, Description: "Act1CharId0"},
+		{Act: 1, Type: ObjectTypeCharacter, Id: 1, Description: "Act1CharId1"},
+		{Act: 1, Type: ObjectTypeCharacter, Id: 2, Description: "Act1CharId2"},
+		{Act: 1, Type: ObjectTypeCharacter, Id: 3, Description: "Act1CharId3"},
+		{Act: 1, Type: ObjectTypeItem, Id: 0, Description: "Act1ItemId0"},
+		{Act: 1, Type: ObjectTypeItem, Id: 1, Description: "Act1ItemId1"},
+		{Act: 1, Type: ObjectTypeItem, Id: 2, Description: "Act1ItemId2"},
+		{Act: 1, Type: ObjectTypeItem, Id: 3, Description: "Act1ItemId3"},
+		{Act: 2, Type: ObjectTypeCharacter, Id: 0, Description: "Act2CharId0"},
+		{Act: 2, Type: ObjectTypeCharacter, Id: 1, Description: "Act2CharId1"},
+		{Act: 2, Type: ObjectTypeCharacter, Id: 2, Description: "Act2CharId2"},
+		{Act: 2, Type: ObjectTypeCharacter, Id: 3, Description: "Act2CharId3"},
+		{Act: 2, Type: ObjectTypeItem, Id: 0, Description: "Act2ItemId0"},
+		{Act: 2, Type: ObjectTypeItem, Id: 1, Description: "Act2ItemId1"},
+		{Act: 2, Type: ObjectTypeItem, Id: 2, Description: "Act2ItemId2"},
+		{Act: 2, Type: ObjectTypeItem, Id: 3, Description: "Act2ItemId3"},
+	}
+
+	indexedTestObjects := indexObjects(testObjects)
+
+	typeCharacter := int(ObjectTypeCharacter)
+	typeItem := int(ObjectTypeItem)
+
+	assert.Equal("Act1CharId2", lookupObject(1, typeCharacter, 2, indexedTestObjects).Description)
+	assert.Equal("Act1ItemId0", lookupObject(1, typeItem, 0, indexedTestObjects).Description)
+	assert.Equal("Act2CharId3", lookupObject(2, typeCharacter, 3, indexedTestObjects).Description)
+	assert.Equal("Act2ItemId1", lookupObject(2, typeItem, 1, indexedTestObjects).Description)
+}


### PR DESCRIPTION
- Move code out of the file with `objectLookups` in it so IDEs won't get bogged down by 7000+ lines of data.
- Index the `objectLookups` array on init so `LookupObject` calls can be made in O(1) instead of O(n).  Since the function is called within a loop it needs to be an inexpensive call.